### PR TITLE
Add args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 composer.json
 composer.lock
 vendor
+test.py

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -260,9 +260,10 @@ class Call():
 
 
 class Node():
-    def __init__(self, token, calls, variables, parent, import_tokens=None,
+    def __init__(self, token, args, calls, variables, parent, import_tokens=None,
                  line_number=None, is_constructor=False):
         self.token = token
+        self.args = args
         self.line_number = line_number
         self.calls = calls
         self.variables = variables

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -348,31 +348,30 @@ class Node():
         if self.line_number is not None:
 
             tbl = f"""
-                <<TABLE CELLSPACING='0' CELLPADDING='10' BORDER='1'>
+                <<TABLE CELLSPACING='0' CELLPADDING='4' BORDER='1'>
                     <TR>
-                        <TD COLSPAN='1' ALIGN='left' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
-                        <TD ALIGN='right' BORDER='0'><B>{self.token}()</B></TD>
+                        <TD COLSPAN='1' ALIGN='LEFT' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
+                        <TD ALIGN='RIGHT' BORDER='0'><B>{self.token}()</B></TD>
                     </TR>
                     <TR>
                 """
             tbl += """
-                        <TD></TD>
                         <TD>
-                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='4'>
+                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='2'>
                                 <TR>
                                     <TD ALIGN='TEXT' BORDER='1'><B>Arguments: </B></TD>
                                 </TR>
                                 <TR>
-                                    <TD>
-                """
+                                    <TD ALIGN='LEFT'>"""
             for arg in self.args:
-                tbl += f"""{arg}/n"""
+                tbl += f"""{arg}<BR ALIGN='LEFT'/>"""
 
             tbl += """
                                     </TD>
                                 </TR>
                             </TABLE>
                         </TD>
+                        <TD></TD>
                     </TR>
                 </TABLE>>
                 """

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -346,7 +346,37 @@ class Node():
         :rtype: str
         """
         if self.line_number is not None:
-            return f"{self.line_number}: {self.token}()"
+
+            tbl = f"""
+                <<TABLE CELLSPACING='0' CELLPADDING='10' BORDER='1'>
+                    <TR>
+                        <TD COLSPAN='1' ALIGN='left' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
+                        <TD ALIGN='right' BORDER='0'><B>{self.token}()</B></TD>
+                    </TR>
+                    <TR>
+                """
+            tbl += """
+                        <TD></TD>
+                        <TD>
+                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='4'>
+                                <TR>
+                                    <TD ALIGN='TEXT' BORDER='1'><B>Arguments: </B></TD>
+                                </TR>
+                                <TR>
+                                    <TD>
+                """
+            for arg in self.args:
+                tbl += f"""{arg}/n"""
+
+            tbl += """
+                                    </TD>
+                                </TR>
+                            </TABLE>
+                        </TD>
+                    </TR>
+                </TABLE>>
+                """
+            return tbl.strip('"')
         return f"{self.token}()"
 
     def remove_from_parent(self):
@@ -410,8 +440,9 @@ class Node():
         attributes = {
             'label': self.label(),
             'name': self.name(),
-            'shape': "rect",
+            'shape': "plaintext",
             'style': 'rounded,filled',
+            'fontname': 'Arial',
             'fillcolor': NODE_COLOR,
         }
         if self.is_trunk:
@@ -421,7 +452,10 @@ class Node():
 
         ret = self.uid + ' ['
         for k, v in attributes.items():
-            ret += f'{k}="{v}" '
+            if k == 'label':
+                ret += f'{k}={v} '
+            else:
+                ret += f'{k}="{v}" '
         ret += ']'
         return ret
 

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -114,7 +114,7 @@ def make_arguments(arguments):
             print('arg: ', arg.arg, ' has annotation: ', arg.annotation.id)
         
         arg_name_list.append(arg.arg)
-        
+
     return arg_name_list
             
         
@@ -215,10 +215,12 @@ class Python(BaseLanguage):
         :rtype: list[Node]
         """
         token = tree.name
+        arguments = make_arguments(tree.args)
         line_number = tree.lineno
         calls = make_calls(tree.body)
         variables = make_local_variables(tree.body, parent)
         is_constructor = False
+
         if parent.group_type == GROUP_TYPE.CLASS and token in ['__init__', '__new__']:
             is_constructor = True
 
@@ -226,7 +228,7 @@ class Python(BaseLanguage):
         if parent.group_type == GROUP_TYPE.FILE:
             import_tokens = [djoin(parent.token, token)]
 
-        return [Node(token, calls, variables, parent, import_tokens=import_tokens,
+        return [Node(token, arguments, calls, variables, parent, import_tokens=import_tokens,
                      line_number=line_number, is_constructor=is_constructor)]
 
     @staticmethod

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -103,7 +103,21 @@ def process_import(element):
         ret.append(Variable(token, points_to=rhs, line_number=element.lineno))
     return ret
 
+def make_arguments(arguments):
 
+    args_obj_list = arguments.args
+    arg_name_list = []
+
+    for arg in args_obj_list:
+        
+        if arg.annotation != None:
+            print('arg: ', arg.arg, ' has annotation: ', arg.annotation.id)
+        
+        arg_name_list.append(arg.arg)
+        
+    return arg_name_list
+            
+        
 def make_local_variables(lines, parent):
     """
     Given an ast of all the lines in a function, generate a list of

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -245,7 +245,7 @@ class Python(BaseLanguage):
         line_number = 0
         calls = make_calls(lines)
         variables = make_local_variables(lines, parent)
-        return Node(token, calls, variables, line_number=line_number, parent=parent)
+        return Node(token, [], calls, variables, line_number=line_number, parent=parent)
 
     @staticmethod
     def make_class_group(tree, parent):


### PR DESCRIPTION
This PR adds Arguments to the functions in each node and displays them as a list in the AST diagram.
- Extended the Node class to save function arguments
- Created a make_arguments function to get a list of arguments for each node
- Reformatted the label of each node to include arguments.